### PR TITLE
skip deserialize list if value doesn't exist in EditorPrefs #2

### DIFF
--- a/CompileTimeTracker/Editor/CompileTimeTrackerData.cs
+++ b/CompileTimeTracker/Editor/CompileTimeTrackerData.cs
@@ -46,7 +46,12 @@ namespace DTCompileTimeTracker {
 
     private void Load() {
       this._startTime = EditorPrefs.GetInt(this._editorPrefKey + "._startTime");
-      this._compileTimeHistory = CompileTimeKeyframe.DeserializeList(EditorPrefs.GetString(this._editorPrefKey + "._compileTimeHistory"));
+      var key = this._editorPrefKey + "._compileTimeHistory";
+      if(EditorPrefs.HasKey(key)) {
+        this._compileTimeHistory = CompileTimeKeyframe.DeserializeList(EditorPrefs.GetString(key));
+      } else {
+        this._compileTimeHistory = new List<CompileTimeKeyframe>();
+      }
     }
   }
 }


### PR DESCRIPTION
Related issue : #2 

## Cause
1. At first run, there is no `this._editorPrefKey + "._compileTimeHistory"` in EditorPrefs.
2. `EditorPrefs.GetString(this._editorPrefKey + "._compileTimeHistory")` returns null
3. Cannot deserialize null. It make error message, `Failed to deserialize CompileTimeKeyframe because splitting by @ did not result in 3 tokens!`

## My solution 
If key exists in EditorPrefs, deserialize it. else, create empty list